### PR TITLE
Update Guava per Dependabot (which says it cannot do it by itself)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>14.0.1</version>
+            <version>24.1.1-jre</version>
         </dependency>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
CVE-2018-10237
Vulnerable versions: > 11.0, < 24.1.1
Patched version: 24.1.1
Unbounded memory allocation in Google Guava 11.0 through 24.x before 24
.1.1 allows remote attackers to conduct denial of service attacks
against servers that depend on this library and deserialize
attacker-provided data, because the AtomicDoubleArray class (when
serialized with Java serialization) and the CompoundOrdering class (when
 serialized with GWT serialization) perform eager allocation without
 appropriate checks on what a client has sent and whether the data size
 is reasonable.