### PR TITLE
Update Guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>32.1.2-jre</version>
         </dependency>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
Due to (low-severity) CVE-2020-8908